### PR TITLE
Add typescript support for packages installed via skypack.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "llm-scraper",
-  "version": "1.2.2",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "llm-scraper",
-      "version": "1.2.2",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "ai": "^3.1.12",
@@ -17,6 +17,7 @@
       "devDependencies": {
         "@ai-sdk/anthropic": "^0.0.30",
         "@ai-sdk/openai": "^0.0.2",
+        "@mozilla/readability": "^0.5.0",
         "@types/node": "^20.12.7",
         "@types/react": "^18.2.79",
         "ollama-ai-provider": "^0.10.0",
@@ -217,6 +218,15 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
+    },
+    "node_modules/@mozilla/readability": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@mozilla/readability/-/readability-0.5.0.tgz",
+      "integrity": "sha512-Z+CZ3QaosfFaTqvhQsIktyGrjFjSC0Fa4EMph4mqKnWhmyoGICsV/8QK+8HpXut6zV7zwfWwqDmEjtk1Qf6EgQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@octokit/app": {
       "version": "14.1.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "devDependencies": {
     "@ai-sdk/anthropic": "^0.0.30",
     "@ai-sdk/openai": "^0.0.2",
+    "@mozilla/readability": "^0.5.0",
     "@types/node": "^20.12.7",
     "@types/react": "^18.2.79",
     "ollama-ai-provider": "^0.10.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,16 +14,16 @@ import cleanup from './cleanup.js'
 
 export type ScraperLoadOptions =
   | {
-      format?: 'html' | 'text' | 'markdown' | 'cleanup'
-    }
+    format?: 'html' | 'text' | 'markdown' | 'cleanup'
+  }
   | {
-      format: 'custom'
-      formatFunction: (page: Page) => Promise<string> | string
-    }
+    format: 'custom'
+    formatFunction: (page: Page) => Promise<string> | string
+  }
   | {
-      format: 'image'
-      fullPage?: boolean
-    }
+    format: 'image'
+    fullPage?: boolean
+  }
 
 export type ScraperLoadResult = {
   url: string
@@ -65,14 +65,12 @@ export default class LLMScraper {
 
     if (options.format === 'text') {
       const readable = await page.evaluate(async () => {
-        const readability = await import(
-          // @ts-ignore
+        const { Readability } = await import(
           'https://cdn.skypack.dev/@mozilla/readability'
         )
 
-        return new readability.Readability(document).parse()
+        return new Readability(document).parse()
       })
-
       content = `Page Title: ${readable.title}\n${readable.textContent}`
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,16 @@
   "compilerOptions": {
     "outDir": "dist",
     "declaration": true,
-    "lib": ["ESNext", "DOM"],
+    "lib": [
+      "ESNext",
+      "DOM"
+    ],
     "module": "NodeNext",
     "target": "ESNext",
     "moduleResolution": "NodeNext"
   },
-  "include": ["src/**/*.ts"]
+  "include": [
+    "src/**/*.ts",
+    "types/**/*.d.ts"
+  ]
 }

--- a/types/skypack.d.ts
+++ b/types/skypack.d.ts
@@ -1,0 +1,9 @@
+/**
+ * https://docs.skypack.dev/skypack-cdn/code/javascript#using-skypack-urls-in-typescript
+ * 
+ * **/
+declare module 'https://cdn.skypack.dev/*';
+
+declare module 'https://cdn.skypack.dev/@mozilla/readability' {
+    export * from '@mozilla/readability';
+}


### PR DESCRIPTION
As per: https://docs.skypack.dev/skypack-cdn/code/javascript#using-skypack-urls-in-typescript

Adding '@mozilla/readability' to dev dependencies then allows to resolve for it's types, without having to bundle everything up in production builds.