### PR TITLE
fix: replace CDN-loaded Readability with server-side @mozilla/readability

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,11 +27,14 @@
   "homepage": "https://github.com/mishushakov/llm-scraper#readme",
   "dependencies": {
     "@ai-sdk/provider": "^3.0.8",
+    "@mozilla/readability": "^0.6.0",
     "ai": "^6.0.77",
+    "jsdom": "^29.0.2",
     "turndown": "^7.2.2"
   },
   "devDependencies": {
     "@ai-sdk/openai": "^3.0.26",
+    "@types/jsdom": "^21.1.7",
     "@types/node": "^25.2.1",
     "@types/react": "^19.2.13",
     "playwright": "^1.58.2",

--- a/src/preprocess.ts
+++ b/src/preprocess.ts
@@ -1,4 +1,6 @@
 import { type Page } from 'playwright'
+import { Readability } from '@mozilla/readability'
+import { JSDOM } from 'jsdom'
 import Turndown from 'turndown'
 
 import cleanup from './cleanup.js'
@@ -40,16 +42,16 @@ export async function preprocess(
   }
 
   if (format === 'text') {
-    const readable = await page.evaluate(async () => {
-      const readability = await import(
-        // @ts-ignore
-        'https://cdn.skypack.dev/@mozilla/readability'
-      )
+    const html = await page.content()
+    const dom = new JSDOM(html, { url })
+    const reader = new Readability(dom.window.document)
+    const article = reader.parse()
 
-      return new readability.Readability(document).parse()
-    })
-
-    content = `Page Title: ${readable.title}\n${readable.textContent}`
+    if (article) {
+      content = `Page Title: ${article.title}\n${article.textContent}`
+    } else {
+      content = await page.innerText('body')
+    }
   }
 
   if (format === 'html') {


### PR DESCRIPTION
Fixes #8

## Problem

The `text` format mode loaded `@mozilla/readability` from the skypack CDN via `page.evaluate()`, which runs in the browser context. Sites with strict Content Security Policy (CSP) — like Hacker News — block external CDN URLs in their `script-src` directive, causing the import to fail silently or throw an error.

## Solution

Replace the in-browser CDN import with a server-side approach:

1. Fetch the page HTML using `page.content()` (runs in Node.js, not the browser)
2. Parse it with `@mozilla/readability` + `jsdom` on the server side, where CSP restrictions do not apply
3. Fall back to `page.innerText('body')` if Readability cannot extract an article

This moves the dependency from a runtime CDN fetch to a proper npm package, making it reliable across all sites regardless of their CSP.

## Changes

- `src/preprocess.ts`: Replace `page.evaluate()` CDN import with server-side `Readability` + `JSDOM`
- `package.json`: Add `@mozilla/readability` and `jsdom` as dependencies; add `@types/jsdom` as devDependency

## Testing

The fix can be verified by running the scraper in `text` mode against `https://news.ycombinator.com`, which previously failed due to CSP blocking the skypack CDN.